### PR TITLE
Add auto alias on select

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -32,9 +32,10 @@ class OOQuery(object):
                 join = self.parser.joins_map.get(path)
                 if join:
                     table = join.right
-                    fields.append(getattr(table, field.split('.')[-1]))
+                    table_field = getattr(table, field.split('.')[-1])
             else:
-                fields.append(getattr(self.table, field))
+                table_field = getattr(self.table, field)
+            fields.append(table_field.as_(field.replace('.', '_')))
         return fields
 
     def select(self, fields=None, **kwargs):


### PR DESCRIPTION
This feature add an option to get an auto descriptive alias.

E.g.

```python
sql = q.select(['name', 'table1.name', 'table2.name']).where([])
```
If you fetch the results *as dict* you then get the following keys:

* name
* table1_name
* table2_name