### PR TITLE
Initialize parser on select

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -10,8 +10,9 @@ class OOQuery(object):
     def __init__(self, table, foreign_key=None):
         self._fields = []
         self.table = Table(table)
+        self.foreign_key = foreign_key
         self._select = self.table.select()
-        self.parser = Parser(self.table, foreign_key)
+        self.parser = Parser(self.table, self.foreign_key)
         self.select_opts = {}
 
     @property
@@ -39,6 +40,7 @@ class OOQuery(object):
         return fields
 
     def select(self, fields=None, **kwargs):
+        self.parser = Parser(self.table, self.foreign_key)
         self._fields = fields
         self.select_opts = kwargs
         order_by = kwargs.pop('order_by', None)

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -193,3 +193,28 @@ with description('The OOQuery object'):
             join.condition = join.left.table_2 == join.right.id
             sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2_name'))
             expect(tuple(sql)).to(equal(tuple(sel)))
+
+        with context('on every select'):
+            with it('parser must be initialized'):
+                def dummy_fk(table):
+                    if table == 'table':
+                        return {
+                            'parent_id': {
+                                'constraint_name': 'fk_contraint_name',
+                                'table_name': 'table',
+                                'column_name': 'parent_id',
+                                'foreign_table_name': 'table',
+                                'foreign_column_name': 'id'
+                            },
+                        }
+
+
+                q = OOQuery('table', dummy_fk)
+                sql = q.select(['id', 'name']).where([
+                    ('parent_id.ean13', '=', '3020178572427')
+                ])
+                parser = q.parser
+                sql = q.select(['id', 'name']).where([
+                    ('parent_id.ean13', '=', '3020178572427')
+                ])
+                expect(q.parser).to(not_(equal(parser)))

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -84,7 +84,7 @@ with description('A parser'):
             expect(p.joins_map).to(have_key('table_2'))
             expect(str(p.joins_map['table_2'])).to(equal(str(join)))
 
-        with it('must have a function to get a jon'):
+        with it('must have a function to get a join'):
             def dummy_fk(table):
                 if table == 'table':
                     return {


### PR DESCRIPTION
On select reinitialize `parser` object this allows us to execute `.select()` without instantiate OOQuery every time
