### PR TITLE
Separate used joins from available joins

### DIFF
--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -47,6 +47,9 @@ class Parser(object):
                 self.joins.append(join)
                 table = table_join
             else:
+                if join not in self.joins:
+                    self.joins.append(join)
+
                 table = join.right
 
     def parse(self, query):

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -14,14 +14,11 @@ class Parser(object):
         self.operators = OPERATORS_MAP
         self.table = table
         self.joins_map = OrderedDict()
+        self.joins = []
         self.foreign_key = foreign_key
 
     def get_join(self, dottet_path):
         return self.joins_map.get(dottet_path, None)
-
-    @property
-    def joins(self):
-        return list(self.joins_map.values())
 
     @property
     def join_on(self):
@@ -47,6 +44,7 @@ class Parser(object):
                 join = self.join_on.join(table_join)
                 join.condition = Equal(column, fk_col)
                 self.joins_map[dotted_path] = join
+                self.joins.append(join)
                 table = table_join
             else:
                 table = join.right

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -17,6 +17,8 @@ class Parser(object):
         self.joins = []
         self.foreign_key = foreign_key
 
+        self.join_path = []
+
     def get_join(self, dottet_path):
         return self.joins_map.get(dottet_path, None)
 
@@ -29,16 +31,16 @@ class Parser(object):
 
     def parse_join(self, fields_join):
         table = self.table
-        join_path = []
+        self.join_path = []
         for field_join in fields_join:
-            join_path.append(field_join)
+            self.join_path.append(field_join)
             fk = self.foreign_key(table._name)[field_join]
             table_join = Table(fk['foreign_table_name'])
             join = Join(self.join_on, table_join)
             column = getattr(table, fk['column_name'])
             fk_col = getattr(join.right, fk['foreign_column_name'])
             join.condition = Equal(column, fk_col)
-            dotted_path = '.'.join(join_path)
+            dotted_path = '.'.join(self.join_path)
             join = self.get_join(dotted_path)
             if not join:
                 join = self.join_on.join(table_join)

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -15,9 +15,8 @@ class Parser(object):
         self.table = table
         self.joins_map = OrderedDict()
         self.joins = []
-        self.foreign_key = foreign_key
-
         self.join_path = []
+        self.foreign_key = foreign_key
 
     def get_join(self, dottet_path):
         return self.joins_map.get(dottet_path, None)

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -219,5 +219,7 @@ with description('A parser'):
             expect(p.joins).to(have_len(2))
             expect(p.joins_map).to(have_len(2))
 
-            expect(str(p.joins[1])).to(equal(str(custom_join)))
-            expect(p.joins[1]).to(equal(custom_join))
+            index = p.joins.index(custom_join)
+
+            expect(str(p.joins[index])).to(equal(str(custom_join)))
+            expect(p.joins[index]).to(equal(custom_join))

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -141,3 +141,47 @@ with description('A parser'):
                 join2.right.code == 'XXX',
                 join.right.state == 'open'
             ))
+        with it('must allow for predefined joins'):
+            def dummy_fk(table):
+                return {
+                    'table_2': {
+                        'constraint_name': 'fk_contraint_name',
+                        'table_name': 'table',
+                        'column_name': 'table_2',
+                        'foreign_table_name': 'table2',
+                        'foreign_column_name': 'id'
+                    },
+                    'table_3': {
+                        'constraint_name': 'fk_contraint_name',
+                        'table_name': 'table',
+                        'column_name': 'table_3',
+                        'foreign_table_name': 'table3',
+                        'foreign_column_name': 'id'
+                    }
+                }
+
+            t = Table('table')
+            t3 = Table('table3')
+            p = Parser(t, dummy_fk)
+
+            expect(p.joins).to(have_len(0))
+            expect(p.joins_map).to(have_len(0))
+
+            custom_join = t.join(t3)
+            custom_join.condition = t.table_3 == custom_join.right.id
+            p.joins_map['table_3'] = custom_join
+
+            expect(p.joins).to(have_len(0))
+            expect(p.joins_map).to(have_len(1))
+
+            x = p.parse([('table_2.code', '=', 'XXX')])
+
+            expect(p.joins).to(have_len(1))
+            expect(p.joins_map).to(have_len(2))
+
+            join = t.join(Table('table2'))
+            join.condition = join.left.table_2 == join.right.id
+
+            expect(str(p.joins[0])).to(equal(str(join)))
+            expect(p.joins_map).to(have_key('table_2'))
+            expect(str(p.joins_map['table_2'])).to(equal(str(join)))

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -185,3 +185,39 @@ with description('A parser'):
             expect(str(p.joins[0])).to(equal(str(join)))
             expect(p.joins_map).to(have_key('table_2'))
             expect(str(p.joins_map['table_2'])).to(equal(str(join)))
+        with it('it must allow custom joins to be added to the search'):
+            def dummy_fk(table):
+                return {
+                    'table_2': {
+                        'constraint_name': 'fk_contraint_name',
+                        'table_name': 'table',
+                        'column_name': 'table_2',
+                        'foreign_table_name': 'table2',
+                        'foreign_column_name': 'id'
+                    },
+                    'table_3': {
+                        'constraint_name': 'fk_contraint_name',
+                        'table_name': 'table',
+                        'column_name': 'table_3',
+                        'foreign_table_name': 'table3',
+                        'foreign_column_name': 'id'
+                    }
+                }
+
+            t = Table('table')
+            t3 = Table('table3')
+            p = Parser(t, dummy_fk)
+
+            custom_join = t.join(t3)
+            custom_join.condition = t.table_3 == custom_join.right.id
+            p.joins_map['table_3'] = custom_join
+
+            x = p.parse(
+                [('table_2.code', '=', 'XXX'), ('table_3.code', '=', 'YYY')]
+            )
+
+            expect(p.joins).to(have_len(2))
+            expect(p.joins_map).to(have_len(2))
+
+            expect(str(p.joins[1])).to(equal(str(custom_join)))
+            expect(p.joins[1]).to(equal(custom_join))


### PR DESCRIPTION
The value joins in parser is now separated to allow to have predefined joins without having to use them in the query.