### PR TITLE
Improve foreing_key function spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,9 @@ Parsers OpenObjectes queries like:
 
    conn = psycopg2.connect("dbname=test user=postgres")
    with conn.cursor() as cursor:
-       def fk_function(table):
-           return get_foreign_keys(cursor, table)
+       def fk_function(table, field):
+           fks = get_foreign_keys(cursor, table)
+           return fks[field]
 
        q = OOQuery('account_invoice', fk_function)
        sql = q.select(['number', 'state']).where([

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -52,7 +52,7 @@ class Parser(object):
         self.join_path = []
         for field_join in fields_join:
             self.join_path.append(field_join)
-            fk = self.foreign_key(table._name)[field_join]
+            fk = self.foreign_key(table._name, field_join)
             table_join = Table(fk['foreign_table_name'])
             join = Join(self.join_on, table_join)
             column = getattr(table, fk['column_name'])

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -25,8 +25,8 @@ with description('The OOQuery object'):
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support joins'):
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'table_2': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -35,6 +35,7 @@ with description('The OOQuery object'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             q = OOQuery('table', dummy_fk)
             sql = q.select(['field1', 'field2', 'table_2.name']).where([
@@ -58,9 +59,9 @@ with description('The OOQuery object'):
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support deep joins'):
-            def dummy_fk(table):
+            def dummy_fk(table, field):
                 if table == 'table':
-                    return {
+                    fks = {
                         'table_2_id': {
                             'constraint_name': 'fk_contraint_name',
                             'table_name': 'table',
@@ -70,7 +71,7 @@ with description('The OOQuery object'):
                         }
                     }
                 elif table == 'table2':
-                    return {
+                    fks = {
                     'table_3_id': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table2',
@@ -79,6 +80,7 @@ with description('The OOQuery object'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
 
             q = OOQuery('table', dummy_fk)
@@ -100,9 +102,9 @@ with description('The OOQuery object'):
             expect(str(q.parser.joins_map['table_2_id.table_3_id'])).to(equal(str(join2)))
 
         with it('must support multiple deep joins'):
-            def dummy_fk(table):
+            def dummy_fk(table, field):
                 if table == 'table':
-                    return {
+                    fks = {
                         'table_2_id': {
                             'constraint_name': 'fk_contraint_name',
                             'table_name': 'table',
@@ -119,7 +121,7 @@ with description('The OOQuery object'):
                         }
                     }
                 elif table == 'table2':
-                    return {
+                    fks = {
                         'table_3_id': {
                             'constraint_name': 'fk_contraint_name',
                             'table_name': 'table2',
@@ -128,6 +130,7 @@ with description('The OOQuery object'):
                             'foreign_column_name': 'id'
                         }
                     }
+                return fks[field]
 
 
             q = OOQuery('table', dummy_fk)
@@ -174,8 +177,8 @@ with description('The OOQuery object'):
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support alias'):
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'table_2': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -184,6 +187,7 @@ with description('The OOQuery object'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             q = OOQuery('table', dummy_fk)
             sql = q.select(['field1', 'field2', 'table_2.name']).where([])
@@ -195,8 +199,8 @@ with description('The OOQuery object'):
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support recursive joins'):
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'parent_id': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -205,6 +209,7 @@ with description('The OOQuery object'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             q = OOQuery('table', dummy_fk)
             sql = q.select(['id']).where([
@@ -223,9 +228,9 @@ with description('The OOQuery object'):
 
         with context('on every select'):
             with it('parser must be initialized'):
-                def dummy_fk(table):
+                def dummy_fk(table, field):
                     if table == 'table':
-                        return {
+                        fks = {
                             'parent_id': {
                                 'constraint_name': 'fk_contraint_name',
                                 'table_name': 'table',
@@ -234,6 +239,7 @@ with description('The OOQuery object'):
                                 'foreign_column_name': 'id'
                             },
                         }
+                        return fks[field]
 
 
                 q = OOQuery('table', dummy_fk)

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -60,8 +60,8 @@ with description('A parser'):
     with context('if an expression have joins'):
         with it('the parser must have the joins of all the expressions'):
 
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'table_2': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -70,6 +70,7 @@ with description('A parser'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             t = Table('table')
             p = Parser(t, dummy_fk)
@@ -85,9 +86,9 @@ with description('A parser'):
             expect(str(p.joins_map['table_2'])).to(equal(str(join)))
 
         with it('must have a function to get a join'):
-            def dummy_fk(table):
+            def dummy_fk(table, field):
                 if table == 'table':
-                    return {
+                    fks = {
                         'table_2_id': {
                             'constraint_name': 'fk_contraint_name',
                             'table_name': 'table',
@@ -104,7 +105,7 @@ with description('A parser'):
                         }
                     }
                 elif table == 'table2':
-                    return {
+                    fks = {
                         'table_3_id': {
                             'constraint_name': 'fk_contraint_name',
                             'table_name': 'table2',
@@ -113,6 +114,7 @@ with description('A parser'):
                             'foreign_column_name': 'id'
                         }
                     }
+                return fks[field]
 
 
             t = Table('table')
@@ -142,8 +144,8 @@ with description('A parser'):
                 join.right.state == 'open'
             ))
         with it('must allow for predefined joins'):
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'table_2': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -159,6 +161,7 @@ with description('A parser'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             t = Table('table')
             t3 = Table('table3')
@@ -186,8 +189,8 @@ with description('A parser'):
             expect(p.joins_map).to(have_key('table_2'))
             expect(str(p.joins_map['table_2'])).to(equal(str(join)))
         with it('it must allow custom joins to be added to the search'):
-            def dummy_fk(table):
-                return {
+            def dummy_fk(table, field):
+                fks = {
                     'table_2': {
                         'constraint_name': 'fk_contraint_name',
                         'table_name': 'table',
@@ -203,6 +206,7 @@ with description('A parser'):
                         'foreign_column_name': 'id'
                     }
                 }
+                return fks[field]
 
             t = Table('table')
             t3 = Table('table3')


### PR DESCRIPTION
Change the way of getting the foreign key values.

Before this change every time we want the foreign key spec we only call the method with the table name and a dict of all foreign keys was return, but we only need one field.

Now we call the foreign key as following: `foreign_key(table, field)` and the method will return the foreign key spec. This can be an improvement because in some cases we don't needed to build a complete spec for all the foreign keys if they aren't needed.