### PR TITLE
Don't replace '.' for '_' in field name

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -30,7 +30,7 @@ class OOQuery(object):
         fields = []
         for field in self._fields:
             table_field = self.parser.get_table_field(self.table, field)
-            fields.append(table_field.as_(field.replace('.', '_')))
+            fields.append(table_field.as_(field))
         return fields
 
     def select(self, fields=None, **kwargs):

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -45,7 +45,7 @@ with description('The OOQuery object'):
             t2 = Table('table2')
             join = t.join(t2)
             join.condition = join.left.table_2 == join.right.id
-            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2_name'))
+            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
             sel.where = And((join.right.code == 'XXX',))
             expect(tuple(sql)).to(equal(tuple(sel)))
 
@@ -55,7 +55,7 @@ with description('The OOQuery object'):
             t2 = Table('table2')
             join = t.join(t2)
             join.condition = join.left.table_2 == join.right.id
-            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2_name'))
+            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support deep joins'):
@@ -94,7 +94,7 @@ with description('The OOQuery object'):
             join.condition = t.table_2_id == join.right.id
             join2 = join.join(t3)
             join2.condition = t2.table_3_id == join2.right.id
-            sel = join2.select(t.field1.as_('field1'), t.field2.as_('field2'), t3.name.as_('table_2_id_table_3_id_name'))
+            sel = join2.select(t.field1.as_('field1'), t.field2.as_('field2'), t3.name.as_('table_2_id.table_3_id.name'))
             sel.where = And((join2.right.code == 'XXX',))
             expect(tuple(sql)).to(equal(tuple(sel)))
             expect(q.parser.joins_map).to(have_len(2))
@@ -195,7 +195,7 @@ with description('The OOQuery object'):
             t2 = Table('table2')
             join = t.join(t2)
             join.condition = join.left.table_2 == join.right.id
-            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2_name'))
+            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
             expect(tuple(sql)).to(equal(tuple(sel)))
 
         with it('must support recursive joins'):


### PR DESCRIPTION
This makes that sql returned with joins contains '.' instead of '_'