### PR TITLE
Copy the domain var because is mutable

### DIFF
--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -92,6 +92,7 @@ class Parser(object):
 
     def parse(self, query):
         result = []
+        query = query[:]
         while query:
             expression = query.pop()
             if (not Expression.is_expression(expression)

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -12,6 +12,12 @@ with description('A parser'):
         self.t = Table('table')
         self.p = Parser(self.t)
 
+    with it('parsing a query the origina must be keeped'):
+        domain = [('a', '=', 'b')]
+        domain_orig = domain[:]
+        x = self.p.parse(domain)
+        expect(domain).to(equal(domain_orig))
+
     with it("with a simple notation [('a', '=', 'b')]"):
         x = self.p.parse([('a', '=', 'b')])
         op = And((Equal(self.t.a, 'b') ,))

--- a/spec/parser_spec.py
+++ b/spec/parser_spec.py
@@ -12,7 +12,7 @@ with description('A parser'):
         self.t = Table('table')
         self.p = Parser(self.t)
 
-    with it('parsing a query the origina must be keeped'):
+    with it('parsing a query the original must be keeped'):
         domain = [('a', '=', 'b')]
         domain_orig = domain[:]
         x = self.p.parse(domain)


### PR DESCRIPTION
Copy the list before doing `pop()` because list are mutable