### PR TITLE
Support partial for Conditionals and Operators

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -5,6 +5,7 @@ from functools import reduce
 from sql import Table, Literal
 from sql.aggregate import Aggregate
 from sql.conditionals import Conditional
+from sql.operators import Operator
 from ooquery.parser import Parser
 
 
@@ -48,6 +49,17 @@ class OOQuery(object):
                         param = param.value
                     params.append(param)
                 table_field = cond(*params)
+                fields.append(table_field)
+            elif isinstance(field, Operator):
+                operator = field.__class__
+                operands = []
+                for operand in field._operands:
+                    if not isinstance(operand, Literal):
+                        operand = self.parser.get_table_field(self.table, operand)
+                    else:
+                        operand = operand.value
+                    operands.append(operand)
+                table_field = operator(*operands)
                 fields.append(table_field)
             else:
                 table_field = self.parser.get_table_field(self.table, field)

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import
 from functools import reduce
 
-from sql import Table
+from sql import Table, Literal
 from sql.aggregate import Aggregate
+from sql.conditionals import Conditional
 from ooquery.parser import Parser
 
 
@@ -30,15 +31,27 @@ class OOQuery(object):
     def fields(self):
         fields = []
         for field in self._fields:
-            aggr = None
             if isinstance(field, Aggregate):
                 aggr = field.__class__
                 field = field.expression
-            table_field = self.parser.get_table_field(self.table, field)
-            if aggr:
+                table_field = self.parser.get_table_field(self.table, field)
                 table_field = aggr(table_field)
                 field = '{}_{}'.format(aggr._sql, field).lower()
-            fields.append(table_field.as_(field))
+                fields.append(table_field.as_(field))
+            elif isinstance(field, Conditional):
+                cond = field.__class__
+                params = []
+                for param in field.values:
+                    if not isinstance(param, Literal):
+                        param = self.parser.get_table_field(self.table, param)
+                    else:
+                        param = param.value
+                    params.append(param)
+                table_field = cond(*params)
+                fields.append(table_field)
+            else:
+                table_field = self.parser.get_table_field(self.table, field)
+                fields.append(table_field.as_(field))
         return fields
 
     def select(self, fields=None, **kwargs):

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -237,6 +237,12 @@ with description('The OOQuery object'):
             )
             expect(str(sel._select)).to(equal(str(sel2)))
 
+        with it('must support concat'):
+            q = OOQuery('table')
+            sel = q.select([Concat('field1', Literal(' 01:00'))])
+            sel2 = q.table.select(Concat(q.table.field1, ' 01:00'))
+            expect(str(sel._select)).to(equal(str(sel2)))
+
         with it('must support coalesce'):
             q = OOQuery('table')
             sel = q.select([Coalesce('field1', Literal(3))])

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 from ooquery import OOQuery
-from sql import Table
+from sql import Table, Literal
 from sql.operators import *
 from sql.aggregate import *
+from sql.conditionals import *
 
 from expects import *
 
@@ -234,6 +235,24 @@ with description('The OOQuery object'):
                 Max(q.table.field1).as_('max_field1'),
                 group_by=[q.table.field2]
             )
+            expect(str(sel._select)).to(equal(str(sel2)))
+
+        with it('must support coalesce'):
+            q = OOQuery('table')
+            sel = q.select([Coalesce('field1', Literal(3))])
+            sel2 = q.table.select(Coalesce(q.table.field1, 3))
+            expect(str(sel._select)).to(equal(str(sel2)))
+
+        with it('must support greatest'):
+            q = OOQuery('table')
+            sel = q.select([Greatest('field1', 'field2')])
+            sel2 = q.table.select(Greatest(q.table.field1, q.table.field2))
+            expect(str(sel._select)).to(equal(str(sel2)))
+
+        with it('must support least'):
+            q = OOQuery('table')
+            sel = q.select([Least('field1', 'field2')])
+            sel2 = q.table.select(Least(q.table.field1, q.table.field2))
             expect(str(sel._select)).to(equal(str(sel2)))
 
         with it('must support group by in joined queries'):


### PR DESCRIPTION
Now we can execute queries with coalesce, greatest and least command (conditionals), and concat(operators) using literals for comparison or other fields from other tables.

:warning: Other operators are not tested but are also implemented because we check if base class is an instance of `Operator`.

## Conditionals

eg.

```python
q = OOQuery('account_invoice')
q.select([Coalesce('partner_id.vat', Literal('NO VAT'))]).where([('id', '=', 1234)])
```
or using other fields from table

```python
q = OOQuery('account_invoice')
q.select([Coalesce('number', 'name')]).where([('id', '=', 1234)])
```

## Operators

```python
q = OOQuery('account_invoice')
q.select([Concat(Literal('Invoice: '), 'number'])).where([('id', '=', 1234)])
```
