### PR TITLE
Support to use joined tables in orders

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -50,9 +50,10 @@ class OOQuery(object):
         if order_by:
             kwargs['order_by'] = []
             for item in order_by:
-                kwargs['order_by'].append(
-                    reduce(getattr, item.split('.'), self.select_on)
-                )
+                field, order = item.rsplit('.', 1)
+                field = self.parser.get_table_field(self.table, field)
+                order = getattr(field, order)
+                kwargs['order_by'].append(order)
         if group_by:
             kwargs['group_by'] = []
             for item in group_by:

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -81,9 +81,10 @@ class OOQuery(object):
                 if isinstance(item, NullOrder):
                     null_order = item.__class__
                     item = item.expression
-                field, order = item.rsplit('.', 1)
-                field = self.parser.get_table_field(self.table, field)
-                order = getattr(field, order)
+                order_values = item.rsplit('.', 1)
+                order = self.parser.get_table_field(self.table, order_values[0])
+                if len(order_values) > 1:
+                    order = getattr(order, order_values[1])
                 if null_order:
                     order = null_order(order)
                 kwargs['order_by'].append(order)

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from functools import reduce
 
-from sql import Table, Literal
+from sql import Table, Literal, NullOrder
 from sql.aggregate import Aggregate
 from sql.conditionals import Conditional
 from sql.operators import Operator
@@ -75,9 +75,15 @@ class OOQuery(object):
         if order_by:
             kwargs['order_by'] = []
             for item in order_by:
+                null_order = None
+                if isinstance(item, NullOrder):
+                    null_order = item.__class__
+                    item = item.expression
                 field, order = item.rsplit('.', 1)
                 field = self.parser.get_table_field(self.table, field)
                 order = getattr(field, order)
+                if null_order:
+                    order = null_order(order)
                 kwargs['order_by'].append(order)
         if group_by:
             kwargs['group_by'] = []

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -215,6 +215,14 @@ with description('The OOQuery object'):
                 sel = t.select(t.a.as_('a'), t.b.as_('b'), order_by=(t.a.asc, t.b.desc))
                 expect(tuple(sql)).to(equal(tuple(sel)))
 
+            with it('must support order by field'):
+                q = OOQuery('table', None)
+                sql = q.select(['a', 'b'], order_by=('a', )).where([])
+
+                t = Table('table')
+                sel = t.select(t.a.as_('a'), t.b.as_('b'), order_by=(t.a, ))
+                expect(tuple(sql)).to(equal(tuple(sel)))
+
             with it('must support order in joins'):
 
                 def dummy_fk(table, field):

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -213,7 +213,7 @@ with description('The OOQuery object'):
 
         with it('must support nulls first/nulls last options'):
             q = OOQuery('table', None)
-            sql = q.select(['a', 'b'], order_by=('a.asc.nulls_first', 'b.desc.nulls_last')).where([])
+            sql = q.select(['a', 'b'], order_by=(NullsFirst('a.asc'), NullsLast('b.desc'))).where([])
 
             t = Table('table')
             sel = t.select(t.a.as_('a'), t.b.as_('b'), order_by=(NullsFirst(t.a.asc), NullsLast(t.b.desc)))

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -169,13 +169,46 @@ with description('The OOQuery object'):
             sel = t.select(t.a.as_('a'), t.b.as_('b'), limit=10)
             expect(tuple(sql)).to(equal(tuple(sel)))
 
-        with it('must support order'):
-            q = OOQuery('table', None)
-            sql = q.select(['a', 'b'], order_by=('a.asc', 'b.desc')).where([])
+        with context('when ordening'):
+            with it('must support order'):
+                q = OOQuery('table', None)
+                sql = q.select(['a', 'b'], order_by=('a.asc', 'b.desc')).where([])
 
-            t = Table('table')
-            sel = t.select(t.a.as_('a'), t.b.as_('b'), order_by=(t.a.asc, t.b.desc))
-            expect(tuple(sql)).to(equal(tuple(sel)))
+                t = Table('table')
+                sel = t.select(t.a.as_('a'), t.b.as_('b'), order_by=(t.a.asc, t.b.desc))
+                expect(tuple(sql)).to(equal(tuple(sel)))
+
+            with it('must support order in joins'):
+
+                def dummy_fk(table, field):
+                    fks = {
+                        'table_2': {
+                            'constraint_name': 'fk_contraint_name',
+                            'table_name': 'table',
+                            'column_name': 'table_2',
+                            'foreign_table_name': 'table2',
+                            'foreign_column_name': 'id'
+                        }
+                    }
+                    return fks[field]
+
+                q = OOQuery('table', dummy_fk)
+                sql = q.select(
+                    ['field1', 'field2', 'table_2.name'],
+                    order_by=('table_2.sequence.desc', )
+                ).where([])
+                t = Table('table')
+                t2 = Table('table2')
+                join = t.join(t2)
+                join.condition = join.left.table_2 == join.right.id
+                sel = join.select(
+                    t.field1.as_('field1'),
+                    t.field2.as_('field2'),
+                    t2.name.as_('table_2.name'),
+                    order_by=(t2.sequence.desc, )
+                )
+                expect(tuple(sql)).to(equal(tuple(sel)))
+
 
         with it('must support alias'):
             def dummy_fk(table, field):


### PR DESCRIPTION
Now it's possible to use a joined column for order. eg:

```python
q = OOQuery('account_invoice')
q.select(
    ['number', 'partner_id.name', 'partner_id.vat'],
    order_by=('partner_id.name.asc', )
).where([])
```