### PR TITLE
Improve exception message when a field doest not exist on a specific table

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -64,7 +64,7 @@ class OOQuery(object):
             else:
                 table_field = self.parser.get_table_field(self.table, field)
                 if table_field is None:
-                    raise Exception(
+                    raise AttributeError(
                         u"Field '{field}' does not exist on table: "
                         u"'{table}'".format(
                             field=field, table=self.table._name

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -63,6 +63,13 @@ class OOQuery(object):
                 fields.append(table_field)
             else:
                 table_field = self.parser.get_table_field(self.table, field)
+                if table_field is None:
+                    raise Exception(
+                        u"Field '{field}' does not exist on table: "
+                        u"'{table}'".format(
+                            field=field, table=self.table._name
+                        )
+                    )
                 fields.append(table_field.as_(field))
         return fields
 


### PR DESCRIPTION
## Description
Change message on exception when a field does not exist on a table. 

## Previous behaviour
This was the message that was before: 
```Python
{AttributeError}'NoneType' object has no attribute 'as_'
```

## Current behaviour
That has been replaced by: 
```Python
{Exception}Field <field_name> does not exist on table: <table_name>
```
Example:
```Python
{Exception}Field 'camp_inexistent' does not exist on table: 'giscedata_at_tram'
```