### PR TITLE
Add new as_ parameter to select columns using a different name

### DIFF
--- a/ooquery/expression.py
+++ b/ooquery/expression.py
@@ -48,6 +48,7 @@ class InvalidExpressionException(Exception):
 
 class Field(object):
     __slots__ = ('_name', )
+
     def __init__(self, name):
         self._name = name
 

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -83,7 +83,7 @@ class OOQuery(object):
         if group_by:
             kwargs['group_by'] = []
             for item in group_by:
-                table_field = table_field = self.parser.get_table_field(
+                table_field = self.parser.get_table_field(
                     self.table, item
                 )
                 kwargs['group_by'].append(

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -39,7 +39,7 @@ class OOQuery(object):
                 table_field = self.parser.get_table_field(self.table, field)
                 table_field = aggr(table_field)
                 field = '{}_{}'.format(aggr._sql, field).lower()
-                fields.append(table_field.as_(field))
+                fields.append(table_field.as_(self.as_.get(field, field)))
             elif isinstance(field, Conditional):
                 cond = field.__class__
                 params = []

--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -17,6 +17,7 @@ class OOQuery(object):
         self._select = self.table.select()
         self.parser = self.create_parser()
         self.select_opts = {}
+        self.as_ = {}
 
     def create_parser(self):
         return Parser(self.table, self.foreign_key)
@@ -63,13 +64,14 @@ class OOQuery(object):
                 fields.append(table_field)
             else:
                 table_field = self.parser.get_table_field(self.table, field)
-                fields.append(table_field.as_(field))
+                fields.append(table_field.as_(self.as_.get(field, field)))
         return fields
 
     def select(self, fields=None, **kwargs):
         self.parser = self.create_parser()
         self._fields = fields
         self.select_opts = kwargs
+        self.as_ = kwargs.pop('as_', self.as_)
         order_by = kwargs.pop('order_by', None)
         group_by = kwargs.pop('group_by', None)
         if order_by:

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from collections import OrderedDict
 
-from sql import Table, Join, Literal
+from sql import Table, Join
 from sql.operators import Equal
 
 from ooquery.operators import *

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -307,13 +307,17 @@ with description('The OOQuery object'):
 
         with it('must support as'):
             q = OOQuery('table')
-            sql = q.select(
-                ['a', 'b'], as_={'a': 'first column', 'b': 'second column'}
-            ).where([])
+            sel = q.select(
+                ['field1', 'field2'],
+                as_={'field1': 'first column', 'field2': 'second column'}
+            )
 
-            t = Table('table')
-            sel = t.select(t.a.as_('first column'), t.b.as_('second column'))
-            expect(tuple(sql)).to(equal(tuple(sel)))
+            table = q.table
+            sel2 = table.select(
+                table.field1.as_('first column'),
+                table.field2.as_('second column')
+            )
+            expect(str(sel._select)).to(equal(str(sel2)))
 
         with it('must support group by in joined queries'):
             def dummy_fk(table, field):

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -2,11 +2,12 @@
 from ooquery import OOQuery
 from ooquery.expression import Field
 from sql import Table, Literal, NullsFirst, NullsLast
-from sql.operators import *
-from sql.aggregate import *
-from sql.conditionals import *
+from sql.operators import And, Concat
+from sql.aggregate import Max
+from sql.conditionals import Coalesce, Greatest, Least
 
 from expects import *
+from mamba import *
 
 
 with description('The OOQuery object'):

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -319,6 +319,15 @@ with description('The OOQuery object'):
             )
             expect(str(sel._select)).to(equal(str(sel2)))
 
+        with it('must support as with Aggregate fields'):
+            q = OOQuery('table')
+            sel = q.select(
+                [Max('field1')],
+                as_={'max_field1': 'max first column'}
+            )
+            sel2 = q.table.select(Max(q.table.field1).as_('max first column'))
+            expect(str(sel._select)).to(equal(str(sel2)))
+
         with it('must support group by in joined queries'):
             def dummy_fk(table, field):
                 if table == 'table':

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -304,6 +304,16 @@ with description('The OOQuery object'):
             sel2 = q.table.select(Least(q.table.field1, q.table.field2))
             expect(str(sel._select)).to(equal(str(sel2)))
 
+        with it('must support as'):
+            q = OOQuery('table')
+            sql = q.select(
+                ['a', 'b'], as_={'a': 'first column', 'b': 'second column'}
+            ).where([])
+
+            t = Table('table')
+            sel = t.select(t.a.as_('first column'), t.b.as_('second column'))
+            expect(tuple(sql)).to(equal(tuple(sel)))
+
         with it('must support group by in joined queries'):
             def dummy_fk(table, field):
                 if table == 'table':


### PR DESCRIPTION
## PR Description

- Allows to pass the parameter `as_` to the OOquery select allowing to use a different name than the original column name. For example:

```python
sql = q.select(
    ['a', 'b'], as_={'a': 'first column', 'b': 'second column'}
).where([])
```
- It also allows to use the parameter using Aggregate functions:

```python
sel = q.select(
    [Max('field1')], as_={'max_field1': 'max first column'}
)
```
- Minor improvements