### PR TITLE
Support to use custom joins in select and where.

### DIFF
--- a/ooquery/operators.py
+++ b/ooquery/operators.py
@@ -27,3 +27,49 @@ OPERATORS_MAP = {
     '&': And,
     '!': Not
 }
+
+
+class JoinType(object):
+    type_ = None
+    __slots__ = ('field', )
+
+    def __init__(self, field):
+        self.field = field
+
+    def __repr__(self):
+        return '{}({})'.format(self.type_, self.field)
+
+    def __str__(self):
+        return self.field
+
+
+class InnerJoin(JoinType):
+    type_ = 'INNER'
+
+
+class LeftJoin(JoinType):
+    type_ = 'LEFT'
+
+
+class LeftOuterJoin(JoinType):
+    type_ = 'LEFT OUTER'
+
+
+class RightJoin(JoinType):
+    type_ = 'RIGHT'
+
+
+class RightOuterJoin(JoinType):
+    type_ = 'RIGHT OUTER'
+
+
+class FullJoin(JoinType):
+    type_ = 'FULL'
+
+
+class FullOuterJoin(JoinType):
+    type_ = 'FULL OUTER'
+
+
+class CrossJoin(JoinType):
+    type_ = 'CROSS'

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -63,6 +63,10 @@ class Parser(object):
 
     def parse_join(self, fields_join):
         def convert_join_type(join_type):
+            """
+            :param join_type: '(Type)' where Type is mapped at JOINS_MAP
+            :return: returns its correspondence inside the JOINS_MAP
+            """
             assert join_type.find('(') == 0
             closing_pos = join_type.find(')')
             assert closing_pos != -1
@@ -73,10 +77,13 @@ class Parser(object):
         table = self.table
         self.join_path = []
         for i, field_join in enumerate(fields_join):
+            # We search any '(TYPE)' of join inside field
             join_type = re.findall('\(.*\)', field_join)
             if join_type:
                 join_type = join_type[0]
+                # We erase the parenthesis inside the field name
                 field_join = field_join.replace(join_type, '')
+                # And we overwrite the field inside the fields_join list
                 fields_join[i] = field_join
             else:
                 join_type = '(I)'

--- a/ooquery/parser.py
+++ b/ooquery/parser.py
@@ -14,6 +14,9 @@ import re
 class Parser(object):
 
     JOIN_TYPES_MAP = {
+        # Join types supported by the Join class of sql package.
+        # See the acceptable values inside the _type_ attribute setter of that
+        # class.
         'I': 'INNER',
         'L': 'LEFT',
         'LO': 'LEFT OUTER',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ooquery',
-    version='0.19.0',
+    version='0.20.0-rc1',
     packages=find_packages(),
     url='https://github.com/gisce/ooquery',
     license='MIT',

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -457,7 +457,7 @@ with description('The OOQuery object'):
                 ])
                 expect(q.parser).to(not_(equal(parser)))
 
-        with it('must support differnt joins'):
+        with it('must support different joins'):
 
             def dummy_fk(table, field):
                 fks = {
@@ -478,7 +478,6 @@ with description('The OOQuery object'):
                 }
                 return fks[field]
 
-            # We test if the keyword (L) builds a LEFT join
             q = OOQuery('table', dummy_fk)
             sql = q.select(
                 ['field1', 'field2', LeftJoin('table_2.name')],

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -61,7 +61,6 @@ with description('The OOQuery object'):
             sel.where = And((join.left.field1 == join.right.name,))
             expect(tuple(sql)).to(equal(tuple(sel)))
 
-
         with it('must support joins'):
             def dummy_fk(table, field):
                 fks = {
@@ -427,10 +426,17 @@ with description('The OOQuery object'):
             def dummy_fk(table, field):
                 fks = {
                     'table_2': {
-                        'constraint_name': 'fk_contraint_name',
+                        'constraint_name': 'fk_contraint_name_3',
                         'table_name': 'table',
                         'column_name': 'table_2',
                         'foreign_table_name': 'table2',
+                        'foreign_column_name': 'id'
+                    },
+                    'table_3': {
+                        'constraint_name': 'fk_contraint_name_3',
+                        'table_name': 'table',
+                        'column_name': 'table_3',
+                        'foreign_table_name': 'table3',
                         'foreign_column_name': 'id'
                     }
                 }
@@ -441,23 +447,19 @@ with description('The OOQuery object'):
             sql = q.select(
                 ['field1', 'field2', '(L)table_2.name'],
                 as_={'(L)table_2.name': 'table_2.name'}).where([
-                    ('(L)table_2.code', '=', 'XXX')
+                    ('(LO)table_3.code', '=', 'XXX')
                 ]
             )
             t = Table('table')
             t2 = Table('table2')
+            t3 = Table('table3')
+
             join = t.join(t2, type_='LEFT')
             join.condition = join.left.table_2 == join.right.id
-            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
-            sel.where = And((join.right.code == 'XXX',))
-            expect(tuple(sql)).to(equal(tuple(sel)))
 
-            # If no keyword is indicated, the default join type should be INNER
-            q = OOQuery('table', dummy_fk)
-            sql = q.select(['field1', 'field2', 'table_2.name']).where([])
-            t = Table('table')
-            t2 = Table('table2')
-            join = t.join(t2, type_='INNER')
-            join.condition = join.left.table_2 == join.right.id
-            sel = join.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
+            join2 = join.join(t3, type_='LEFT OUTER')
+            join2.condition = join.left.table_3 == join2.right.id
+
+            sel = join2.select(t.field1.as_('field1'), t.field2.as_('field2'), t2.name.as_('table_2.name'))
+            sel.where = And((join2.right.code == 'XXX',))
             expect(tuple(sql)).to(equal(tuple(sel)))

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -28,7 +28,7 @@ with description('The OOQuery object'):
             sel.where = And((t.field3 == 4,))
             expect(tuple(sql)).to(equal(tuple(sel)))
 
-        with it('should have where mehtod and compare two fields of the table'):
+        with it('should have where method and compare two fields of the table'):
             q = OOQuery('table')
             sql = q.select(['field1', 'field2']).where([('field3', '>', Field('field4'))])
             t = Table('table')

--- a/spec/ooquery_spec.py
+++ b/spec/ooquery_spec.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from ooquery import OOQuery
 from ooquery.expression import Field
+from ooquery.operators import *
 from sql import Table, Literal, NullsFirst, NullsLast
 from sql.operators import And, Concat
 from sql.aggregate import Max
@@ -415,13 +416,7 @@ with description('The OOQuery object'):
                 ])
                 expect(q.parser).to(not_(equal(parser)))
 
-        with it('must construct joins according to keywords given in select'):
-            """
-            We test the custom join functionality, putting a keyword inside 
-            parenthesis before the join dot in select/where clause.
-            The keywords are the initials of the join types: (L)eft, (R)ight, 
-            (RO)outer, ...
-            """
+        with it('must support differnt joins'):
 
             def dummy_fk(table, field):
                 fks = {
@@ -445,11 +440,10 @@ with description('The OOQuery object'):
             # We test if the keyword (L) builds a LEFT join
             q = OOQuery('table', dummy_fk)
             sql = q.select(
-                ['field1', 'field2', '(L)table_2.name'],
-                as_={'(L)table_2.name': 'table_2.name'}).where([
-                    ('(LO)table_3.code', '=', 'XXX')
-                ]
-            )
+                ['field1', 'field2', LeftJoin('table_2.name')],
+            ).where([
+                (LeftOuterJoin('table_3.code'), '=', 'XXX')
+            ])
             t = Table('table')
             t2 = Table('table2')
             t3 = Table('table3')


### PR DESCRIPTION
## Description

Closes #24.
Allow to indicate the join type in the dotted fields, either at select clause of where. 

Usage example: 
```Python
q = OOQuery('account_invoice')
q.select([
    LeftJoin('partner_id.name')
]).where([
    (RightOuterJoin('company_id.name'), '=', 'Tiny splr')
])
```

Generates following SQL: 
```SQL
SELECT "b"."name" AS "partner name"
FROM "account_invoice" AS "a"
LEFT JOIN "res_partner" AS "b" ON ("a"."partner_id" = "b"."id")
RIGHT OUTER JOIN "res_company" AS "c" ON ("a"."company_id" = "c"."id")
WHERE (("c"."name" = %s))
ORDER BY "a"."number"