### PR TITLE
No modificar el noms del camp "id" encara que estigui en una funció de agregació

### DIFF
--- a/ooquery/ooquery.py
+++ b/ooquery/ooquery.py
@@ -38,7 +38,8 @@ class OOQuery(object):
                 field = field.expression
                 table_field = self.parser.get_table_field(self.table, field)
                 table_field = aggr(table_field)
-                field = '{}_{}'.format(aggr._sql, field).lower()
+                if field != 'id':
+                    field = '{}_{}'.format(aggr._sql, field).lower()
                 fields.append(table_field.as_(self.as_.get(field, field)))
             elif isinstance(field, Conditional):
                 cond = field.__class__


### PR DESCRIPTION
El camp 'id' s'espera que sempre existeix en el resultat, per tant no s'ha de modificar el nom en el diccionari resultant encara que s'utilitzi una funció de agregació